### PR TITLE
[Issue 8] Fix db transactions in tests

### DIFF
--- a/tests/unit_tests/services/test_users.py
+++ b/tests/unit_tests/services/test_users.py
@@ -42,6 +42,34 @@ class TestGetUserByUsername:
         assert result is None
 
 
+class TestDelete:
+    """Test the CauseCRUD.delete() method."""
+
+    def test_delete_cascades_to_bookmarks_but_not_causes(
+        self,
+        test_session: Session,
+    ):
+        """Deleting a cause should delete associated bookmarks, but not users."""
+        # set up - confirm alice exists
+        alice_id = uuid5(NAMESPACE, "alice")
+        assert test_session.get(User, alice_id) is not None
+        # setup - confirm cause exists
+        acme_id = uuid5(NAMESPACE, "acme")
+        assert test_session.get(Cause, acme_id) is not None
+        # set up - confirm bookmarks exist
+        bookmark_query = select(Bookmark).where(Bookmark.user_id == alice_id)
+        bookmarks_before = test_session.execute(bookmark_query).scalars().all()
+        assert len(bookmarks_before) == 1
+        # execution
+        user_service.delete(test_session, row_id=alice_id)
+        # validation - confirm user and bookmarks were deleted
+        bookmarks_after = test_session.execute(bookmark_query).scalars().all()
+        assert test_session.get(User, alice_id) is None
+        assert len(bookmarks_after) == 0
+        # validation - confirm cause was NOT deleted
+        assert test_session.get(Cause, acme_id) is not None
+
+
 class TestUpdate:
     """Tests the CauseCRUD.update() method."""
 
@@ -84,31 +112,3 @@ class TestUpdate:
                 assert alice_new[field] == alice_old[field]
             else:
                 assert alice_new[field] == value
-
-
-class TestDelete:
-    """Test the CauseCRUD.delete() method."""
-
-    def test_delete_cascades_to_bookmarks_but_not_causes(
-        self,
-        test_session: Session,
-    ):
-        """Deleting a cause should delete associated bookmarks, but not users."""
-        # set up - confirm alice exists
-        alice_id = uuid5(NAMESPACE, "alice")
-        assert test_session.get(User, alice_id) is not None
-        # setup - confirm cause exists
-        acme_id = uuid5(NAMESPACE, "acme")
-        assert test_session.get(Cause, acme_id) is not None
-        # set up - confirm bookmarks exist
-        bookmark_query = select(Bookmark).where(Bookmark.user_id == alice_id)
-        bookmarks_before = test_session.execute(bookmark_query).scalars().all()
-        assert len(bookmarks_before) == 1
-        # execution
-        user_service.delete(test_session, row_id=alice_id)
-        # validation - confirm user and bookmarks were deleted
-        bookmarks_after = test_session.execute(bookmark_query).scalars().all()
-        assert test_session.get(User, alice_id) is None
-        assert len(bookmarks_after) == 0
-        # validation - confirm cause was NOT deleted
-        assert test_session.get(Cause, acme_id) is not None


### PR DESCRIPTION
## Summary

Updates database fixture to rollback transactions after each test instead of blowing away and recreating the database.

- Fixes #8
- Time to review: 2 minutes

## Changes Proposed

- Monkey patches `session.commit()` with `session.flush()` and `session.expire_all()` to mimic the behavior while still enabling the transaction to be rolled back
- Reorders tests to confirm that test-specific changes are being rolled back

## Instructions to Review

1. Run tests locally before change `make unit-tests` they should take about 5 seconds to complete
2. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
3. Re-run tests with the new changes `make unit-tests` they should finish in around a second or less
